### PR TITLE
Lower minimum required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.5)
 project (raop_play)
 
 find_package(OpenSSL REQUIRED)


### PR DESCRIPTION
Ubuntu 16.04 is shipping with CMake 3.5 and we're not using anything from a newer version ☺️ 