### PR TITLE
Increment `missed` when packet was released

### DIFF
--- a/src/raop_client.c
+++ b/src/raop_client.c
@@ -1383,7 +1383,10 @@ void *_rtp_control_thread(void *args)
 					rtp_header_t *hdr = (rtp_header_t*) raopcld->backlog[index].buffer;
 
 					// packet have been released meanwhile, be extra cautious
-					if (!hdr) continue;
+					if (!hdr) {
+						missed++;
+						continue;
+					}
 
 					hdr->proto = 0x80;
 					hdr->type = 0x56 | 0x80;


### PR DESCRIPTION
@philippe44 `missed` was never incremented and thus always stayed at `0`. I'm far from 100% sure that this is the correct place to increment it though, so please double check and only merge if it looks correct ☺️ 