### PR TITLE
Use <stdint.h> to get properly sized integers

### DIFF
--- a/src/aes.c
+++ b/src/aes.c
@@ -33,23 +33,23 @@
 
 /* forward S-box & tables */
 
-uint32 FSb[256];
-uint32 FT0[256]; 
-uint32 FT1[256]; 
-uint32 FT2[256]; 
-uint32 FT3[256]; 
+uint32_t FSb[256];
+uint32_t FT0[256];
+uint32_t FT1[256];
+uint32_t FT2[256];
+uint32_t FT3[256];
 
 /* reverse S-box & tables */
 
-uint32 RSb[256];
-uint32 RT0[256];
-uint32 RT1[256];
-uint32 RT2[256];
-uint32 RT3[256];
+uint32_t RSb[256];
+uint32_t RT0[256];
+uint32_t RT1[256];
+uint32_t RT2[256];
+uint32_t RT3[256];
 
 /* round constants */
 
-uint32 RCON[10];
+uint32_t RCON[10];
 
 /* tables generation flag */
 
@@ -66,9 +66,9 @@ int do_init = 1;
 void aes_gen_tables( void )
 {
     int i;
-    uint8 x, y;
-    uint8 aes_gen_tables_pow[256];
-    uint8 aes_gen_tables_log[256];
+    uint8_t x, y;
+    uint8_t aes_gen_tables_pow[256];
+    uint8_t aes_gen_tables_log[256];
 
     /* compute pow and log tables over GF(2^8) */
 
@@ -82,7 +82,7 @@ void aes_gen_tables( void )
 
     for( i = 0, x = 1; i < 10; i++, x = XTIME( x ) )
     {
-        RCON[i] = (uint32) x << 24;
+        RCON[i] = (uint32_t) x << 24;
     }
 
     /* generate the forward and reverse S-boxes */
@@ -110,10 +110,10 @@ void aes_gen_tables( void )
     {
         x = FSb[i]; y = XTIME( x );
 
-        FT0[i] =   (uint32) ( x ^ y ) ^
-                 ( (uint32) x <<  8 ) ^
-                 ( (uint32) x << 16 ) ^
-                 ( (uint32) y << 24 );
+        FT0[i] =   (uint32_t) ( x ^ y ) ^
+                 ( (uint32_t) x <<  8 ) ^
+                 ( (uint32_t) x << 16 ) ^
+                 ( (uint32_t) y << 24 );
 
         FT0[i] &= 0xFFFFFFFF;
 
@@ -123,10 +123,10 @@ void aes_gen_tables( void )
 
         y = RSb[i];
 
-        RT0[i] = ( (uint32) MUL( 0x0B, y )       ) ^
-                 ( (uint32) MUL( 0x0D, y ) <<  8 ) ^
-                 ( (uint32) MUL( 0x09, y ) << 16 ) ^
-                 ( (uint32) MUL( 0x0E, y ) << 24 );
+        RT0[i] = ( (uint32_t) MUL( 0x0B, y )       ) ^
+                 ( (uint32_t) MUL( 0x0D, y ) <<  8 ) ^
+                 ( (uint32_t) MUL( 0x09, y ) << 16 ) ^
+                 ( (uint32_t) MUL( 0x0E, y ) << 24 );
 
         RT0[i] &= 0xFFFFFFFF;
 
@@ -140,7 +140,7 @@ void aes_gen_tables( void )
 
 /* forward S-box */
 
-static const uint32 FSb[256] =
+static const uint32_t FSb[256] =
 {
     0x63, 0x7C, 0x77, 0x7B, 0xF2, 0x6B, 0x6F, 0xC5,
     0x30, 0x01, 0x67, 0x2B, 0xFE, 0xD7, 0xAB, 0x76,
@@ -246,26 +246,26 @@ static const uint32 FSb[256] =
     V(7B,B0,B0,CB), V(A8,54,54,FC), V(6D,BB,BB,D6), V(2C,16,16,3A)
 
 #define V(a,b,c,d) 0x##a##b##c##d
-static const uint32 FT0[256] = { FT };
+static const uint32_t FT0[256] = { FT };
 #undef V
 
 #define V(a,b,c,d) 0x##d##a##b##c
-static const uint32 FT1[256] = { FT };
+static const uint32_t FT1[256] = { FT };
 #undef V
 
 #define V(a,b,c,d) 0x##c##d##a##b
-static const uint32 FT2[256] = { FT };
+static const uint32_t FT2[256] = { FT };
 #undef V
 
 #define V(a,b,c,d) 0x##b##c##d##a
-static const uint32 FT3[256] = { FT };
+static const uint32_t FT3[256] = { FT };
 #undef V
 
 #undef FT
 
 /* reverse S-box */
 
-static const uint32 RSb[256] =
+static const uint32_t RSb[256] =
 {
     0x52, 0x09, 0x6A, 0xD5, 0x30, 0x36, 0xA5, 0x38,
     0xBF, 0x40, 0xA3, 0x9E, 0x81, 0xF3, 0xD7, 0xFB,
@@ -371,26 +371,26 @@ static const uint32 RSb[256] =
     V(7B,CB,84,61), V(D5,32,B6,70), V(48,6C,5C,74), V(D0,B8,57,42)
 
 #define V(a,b,c,d) 0x##a##b##c##d
-static const uint32 RT0[256] = { RT };
+static const uint32_t RT0[256] = { RT };
 #undef V
 
 #define V(a,b,c,d) 0x##d##a##b##c
-static const uint32 RT1[256] = { RT };
+static const uint32_t RT1[256] = { RT };
 #undef V
 
 #define V(a,b,c,d) 0x##c##d##a##b
-static const uint32 RT2[256] = { RT };
+static const uint32_t RT2[256] = { RT };
 #undef V
 
 #define V(a,b,c,d) 0x##b##c##d##a
-static const uint32 RT3[256] = { RT };
+static const uint32_t RT3[256] = { RT };
 #undef V
 
 #undef RT
 
 /* round constants */
 
-static const uint32 RCON[10] =
+static const uint32_t RCON[10] =
 {
     0x01000000, 0x02000000, 0x04000000, 0x08000000,
     0x10000000, 0x20000000, 0x40000000, 0x80000000,
@@ -409,35 +409,35 @@ void aes_gen_tables( void )
 
 #define GET_UINT32(n,b,i)                       \
 {                                               \
-    (n) = ( (uint32) (b)[(i)    ] << 24 )       \
-        | ( (uint32) (b)[(i) + 1] << 16 )       \
-        | ( (uint32) (b)[(i) + 2] <<  8 )       \
-        | ( (uint32) (b)[(i) + 3]       );      \
+    (n) = ( (uint32_t) (b)[(i)    ] << 24 )       \
+        | ( (uint32_t) (b)[(i) + 1] << 16 )       \
+        | ( (uint32_t) (b)[(i) + 2] <<  8 )       \
+        | ( (uint32_t) (b)[(i) + 3]       );      \
 }
 
 #define PUT_UINT32(n,b,i)                       \
 {                                               \
-    (b)[(i)    ] = (uint8) ( (n) >> 24 );       \
-    (b)[(i) + 1] = (uint8) ( (n) >> 16 );       \
-    (b)[(i) + 2] = (uint8) ( (n) >>  8 );       \
-    (b)[(i) + 3] = (uint8) ( (n)       );       \
+    (b)[(i)    ] = (uint8_t) ( (n) >> 24 );       \
+    (b)[(i) + 1] = (uint8_t) ( (n) >> 16 );       \
+    (b)[(i) + 2] = (uint8_t) ( (n) >>  8 );       \
+    (b)[(i) + 3] = (uint8_t) ( (n)       );       \
 }
 
 /* decryption key schedule tables */
 
 int KT_init = 1;
 
-uint32 KT0[256];
-uint32 KT1[256];
-uint32 KT2[256];
-uint32 KT3[256];
+uint32_t KT0[256];
+uint32_t KT1[256];
+uint32_t KT2[256];
+uint32_t KT3[256];
 
 /* AES key scheduling routine */
 
-int aes_set_key( aes_context *ctx, uint8 *key, int nbits )
+int aes_set_key( aes_context *ctx, uint8_t *key, int nbits )
 {
     int i;
-    uint32 *RK, *SK;
+    uint32_t *RK, *SK;
 
     if( do_init )
     {
@@ -470,10 +470,10 @@ int aes_set_key( aes_context *ctx, uint8 *key, int nbits )
         for( i = 0; i < 10; i++, RK += 4 )
         {
             RK[4]  = RK[0] ^ RCON[i] ^
-                        ( FSb[ (uint8) ( RK[3] >> 16 ) ] << 24 ) ^
-                        ( FSb[ (uint8) ( RK[3] >>  8 ) ] << 16 ) ^
-                        ( FSb[ (uint8) ( RK[3]       ) ] <<  8 ) ^
-                        ( FSb[ (uint8) ( RK[3] >> 24 ) ]       );
+                        ( FSb[ (uint8_t) ( RK[3] >> 16 ) ] << 24 ) ^
+                        ( FSb[ (uint8_t) ( RK[3] >>  8 ) ] << 16 ) ^
+                        ( FSb[ (uint8_t) ( RK[3]       ) ] <<  8 ) ^
+                        ( FSb[ (uint8_t) ( RK[3] >> 24 ) ]       );
 
             RK[5]  = RK[1] ^ RK[4];
             RK[6]  = RK[2] ^ RK[5];
@@ -486,10 +486,10 @@ int aes_set_key( aes_context *ctx, uint8 *key, int nbits )
         for( i = 0; i < 8; i++, RK += 6 )
         {
             RK[6]  = RK[0] ^ RCON[i] ^
-                        ( FSb[ (uint8) ( RK[5] >> 16 ) ] << 24 ) ^
-                        ( FSb[ (uint8) ( RK[5] >>  8 ) ] << 16 ) ^
-                        ( FSb[ (uint8) ( RK[5]       ) ] <<  8 ) ^
-                        ( FSb[ (uint8) ( RK[5] >> 24 ) ]       );
+                        ( FSb[ (uint8_t) ( RK[5] >> 16 ) ] << 24 ) ^
+                        ( FSb[ (uint8_t) ( RK[5] >>  8 ) ] << 16 ) ^
+                        ( FSb[ (uint8_t) ( RK[5]       ) ] <<  8 ) ^
+                        ( FSb[ (uint8_t) ( RK[5] >> 24 ) ]       );
 
             RK[7]  = RK[1] ^ RK[6];
             RK[8]  = RK[2] ^ RK[7];
@@ -504,20 +504,20 @@ int aes_set_key( aes_context *ctx, uint8 *key, int nbits )
         for( i = 0; i < 7; i++, RK += 8 )
         {
             RK[8]  = RK[0] ^ RCON[i] ^
-                        ( FSb[ (uint8) ( RK[7] >> 16 ) ] << 24 ) ^
-                        ( FSb[ (uint8) ( RK[7] >>  8 ) ] << 16 ) ^
-                        ( FSb[ (uint8) ( RK[7]       ) ] <<  8 ) ^
-                        ( FSb[ (uint8) ( RK[7] >> 24 ) ]       );
+                        ( FSb[ (uint8_t) ( RK[7] >> 16 ) ] << 24 ) ^
+                        ( FSb[ (uint8_t) ( RK[7] >>  8 ) ] << 16 ) ^
+                        ( FSb[ (uint8_t) ( RK[7]       ) ] <<  8 ) ^
+                        ( FSb[ (uint8_t) ( RK[7] >> 24 ) ]       );
 
             RK[9]  = RK[1] ^ RK[8];
             RK[10] = RK[2] ^ RK[9];
             RK[11] = RK[3] ^ RK[10];
 
             RK[12] = RK[4] ^
-                        ( FSb[ (uint8) ( RK[11] >> 24 ) ] << 24 ) ^
-                        ( FSb[ (uint8) ( RK[11] >> 16 ) ] << 16 ) ^
-                        ( FSb[ (uint8) ( RK[11] >>  8 ) ] <<  8 ) ^
-                        ( FSb[ (uint8) ( RK[11]       ) ]       );
+                        ( FSb[ (uint8_t) ( RK[11] >> 24 ) ] << 24 ) ^
+                        ( FSb[ (uint8_t) ( RK[11] >> 16 ) ] << 16 ) ^
+                        ( FSb[ (uint8_t) ( RK[11] >>  8 ) ] <<  8 ) ^
+                        ( FSb[ (uint8_t) ( RK[11]       ) ]       );
 
             RK[13] = RK[5] ^ RK[12];
             RK[14] = RK[6] ^ RK[13];
@@ -552,25 +552,25 @@ int aes_set_key( aes_context *ctx, uint8 *key, int nbits )
     {
         RK -= 8;
 
-        *SK++ = KT0[ (uint8) ( *RK >> 24 ) ] ^
-                KT1[ (uint8) ( *RK >> 16 ) ] ^
-                KT2[ (uint8) ( *RK >>  8 ) ] ^
-                KT3[ (uint8) ( *RK       ) ]; RK++;
+        *SK++ = KT0[ (uint8_t) ( *RK >> 24 ) ] ^
+                KT1[ (uint8_t) ( *RK >> 16 ) ] ^
+                KT2[ (uint8_t) ( *RK >>  8 ) ] ^
+                KT3[ (uint8_t) ( *RK       ) ]; RK++;
 
-        *SK++ = KT0[ (uint8) ( *RK >> 24 ) ] ^
-                KT1[ (uint8) ( *RK >> 16 ) ] ^
-                KT2[ (uint8) ( *RK >>  8 ) ] ^
-                KT3[ (uint8) ( *RK       ) ]; RK++;
+        *SK++ = KT0[ (uint8_t) ( *RK >> 24 ) ] ^
+                KT1[ (uint8_t) ( *RK >> 16 ) ] ^
+                KT2[ (uint8_t) ( *RK >>  8 ) ] ^
+                KT3[ (uint8_t) ( *RK       ) ]; RK++;
 
-        *SK++ = KT0[ (uint8) ( *RK >> 24 ) ] ^
-                KT1[ (uint8) ( *RK >> 16 ) ] ^
-                KT2[ (uint8) ( *RK >>  8 ) ] ^
-                KT3[ (uint8) ( *RK       ) ]; RK++;
+        *SK++ = KT0[ (uint8_t) ( *RK >> 24 ) ] ^
+                KT1[ (uint8_t) ( *RK >> 16 ) ] ^
+                KT2[ (uint8_t) ( *RK >>  8 ) ] ^
+                KT3[ (uint8_t) ( *RK       ) ]; RK++;
 
-        *SK++ = KT0[ (uint8) ( *RK >> 24 ) ] ^
-                KT1[ (uint8) ( *RK >> 16 ) ] ^
-                KT2[ (uint8) ( *RK >>  8 ) ] ^
-                KT3[ (uint8) ( *RK       ) ]; RK++;
+        *SK++ = KT0[ (uint8_t) ( *RK >> 24 ) ] ^
+                KT1[ (uint8_t) ( *RK >> 16 ) ] ^
+                KT2[ (uint8_t) ( *RK >>  8 ) ] ^
+                KT3[ (uint8_t) ( *RK       ) ]; RK++;
     }
 
     RK -= 8;
@@ -585,9 +585,9 @@ int aes_set_key( aes_context *ctx, uint8 *key, int nbits )
 
 /* AES 128-bit block encryption routine */
 
-void aes_encrypt( aes_context *ctx, uint8 input[16], uint8 output[16] )
+void aes_encrypt( aes_context *ctx, uint8_t input[16], uint8_t output[16] )
 {
-    uint32 *RK, X0, X1, X2, X3, Y0, Y1, Y2, Y3;
+    uint32_t *RK, X0, X1, X2, X3, Y0, Y1, Y2, Y3;
 
     RK = ctx->erk;
 
@@ -600,25 +600,25 @@ void aes_encrypt( aes_context *ctx, uint8 input[16], uint8 output[16] )
 {                                               \
     RK += 4;                                    \
                                                 \
-    X0 = RK[0] ^ FT0[ (uint8) ( Y0 >> 24 ) ] ^  \
-                 FT1[ (uint8) ( Y1 >> 16 ) ] ^  \
-                 FT2[ (uint8) ( Y2 >>  8 ) ] ^  \
-                 FT3[ (uint8) ( Y3       ) ];   \
+    X0 = RK[0] ^ FT0[ (uint8_t) ( Y0 >> 24 ) ] ^  \
+                 FT1[ (uint8_t) ( Y1 >> 16 ) ] ^  \
+                 FT2[ (uint8_t) ( Y2 >>  8 ) ] ^  \
+                 FT3[ (uint8_t) ( Y3       ) ];   \
                                                 \
-    X1 = RK[1] ^ FT0[ (uint8) ( Y1 >> 24 ) ] ^  \
-                 FT1[ (uint8) ( Y2 >> 16 ) ] ^  \
-                 FT2[ (uint8) ( Y3 >>  8 ) ] ^  \
-                 FT3[ (uint8) ( Y0       ) ];   \
+    X1 = RK[1] ^ FT0[ (uint8_t) ( Y1 >> 24 ) ] ^  \
+                 FT1[ (uint8_t) ( Y2 >> 16 ) ] ^  \
+                 FT2[ (uint8_t) ( Y3 >>  8 ) ] ^  \
+                 FT3[ (uint8_t) ( Y0       ) ];   \
                                                 \
-    X2 = RK[2] ^ FT0[ (uint8) ( Y2 >> 24 ) ] ^  \
-                 FT1[ (uint8) ( Y3 >> 16 ) ] ^  \
-                 FT2[ (uint8) ( Y0 >>  8 ) ] ^  \
-                 FT3[ (uint8) ( Y1       ) ];   \
+    X2 = RK[2] ^ FT0[ (uint8_t) ( Y2 >> 24 ) ] ^  \
+                 FT1[ (uint8_t) ( Y3 >> 16 ) ] ^  \
+                 FT2[ (uint8_t) ( Y0 >>  8 ) ] ^  \
+                 FT3[ (uint8_t) ( Y1       ) ];   \
                                                 \
-    X3 = RK[3] ^ FT0[ (uint8) ( Y3 >> 24 ) ] ^  \
-                 FT1[ (uint8) ( Y0 >> 16 ) ] ^  \
-                 FT2[ (uint8) ( Y1 >>  8 ) ] ^  \
-                 FT3[ (uint8) ( Y2       ) ];   \
+    X3 = RK[3] ^ FT0[ (uint8_t) ( Y3 >> 24 ) ] ^  \
+                 FT1[ (uint8_t) ( Y0 >> 16 ) ] ^  \
+                 FT2[ (uint8_t) ( Y1 >>  8 ) ] ^  \
+                 FT3[ (uint8_t) ( Y2       ) ];   \
 }
 
     AES_FROUND( Y0, Y1, Y2, Y3, X0, X1, X2, X3 );       /* round 1 */
@@ -647,25 +647,25 @@ void aes_encrypt( aes_context *ctx, uint8 input[16], uint8 output[16] )
 
     RK += 4;
 
-    X0 = RK[0] ^ ( FSb[ (uint8) ( Y0 >> 24 ) ] << 24 ) ^
-                 ( FSb[ (uint8) ( Y1 >> 16 ) ] << 16 ) ^
-                 ( FSb[ (uint8) ( Y2 >>  8 ) ] <<  8 ) ^
-                 ( FSb[ (uint8) ( Y3       ) ]       );
+    X0 = RK[0] ^ ( FSb[ (uint8_t) ( Y0 >> 24 ) ] << 24 ) ^
+                 ( FSb[ (uint8_t) ( Y1 >> 16 ) ] << 16 ) ^
+                 ( FSb[ (uint8_t) ( Y2 >>  8 ) ] <<  8 ) ^
+                 ( FSb[ (uint8_t) ( Y3       ) ]       );
 
-    X1 = RK[1] ^ ( FSb[ (uint8) ( Y1 >> 24 ) ] << 24 ) ^
-                 ( FSb[ (uint8) ( Y2 >> 16 ) ] << 16 ) ^
-                 ( FSb[ (uint8) ( Y3 >>  8 ) ] <<  8 ) ^
-                 ( FSb[ (uint8) ( Y0       ) ]       );
+    X1 = RK[1] ^ ( FSb[ (uint8_t) ( Y1 >> 24 ) ] << 24 ) ^
+                 ( FSb[ (uint8_t) ( Y2 >> 16 ) ] << 16 ) ^
+                 ( FSb[ (uint8_t) ( Y3 >>  8 ) ] <<  8 ) ^
+                 ( FSb[ (uint8_t) ( Y0       ) ]       );
 
-    X2 = RK[2] ^ ( FSb[ (uint8) ( Y2 >> 24 ) ] << 24 ) ^
-                 ( FSb[ (uint8) ( Y3 >> 16 ) ] << 16 ) ^
-                 ( FSb[ (uint8) ( Y0 >>  8 ) ] <<  8 ) ^
-                 ( FSb[ (uint8) ( Y1       ) ]       );
+    X2 = RK[2] ^ ( FSb[ (uint8_t) ( Y2 >> 24 ) ] << 24 ) ^
+                 ( FSb[ (uint8_t) ( Y3 >> 16 ) ] << 16 ) ^
+                 ( FSb[ (uint8_t) ( Y0 >>  8 ) ] <<  8 ) ^
+                 ( FSb[ (uint8_t) ( Y1       ) ]       );
 
-    X3 = RK[3] ^ ( FSb[ (uint8) ( Y3 >> 24 ) ] << 24 ) ^
-                 ( FSb[ (uint8) ( Y0 >> 16 ) ] << 16 ) ^
-                 ( FSb[ (uint8) ( Y1 >>  8 ) ] <<  8 ) ^
-                 ( FSb[ (uint8) ( Y2       ) ]       );
+    X3 = RK[3] ^ ( FSb[ (uint8_t) ( Y3 >> 24 ) ] << 24 ) ^
+                 ( FSb[ (uint8_t) ( Y0 >> 16 ) ] << 16 ) ^
+                 ( FSb[ (uint8_t) ( Y1 >>  8 ) ] <<  8 ) ^
+                 ( FSb[ (uint8_t) ( Y2       ) ]       );
 
     PUT_UINT32( X0, output,  0 );
     PUT_UINT32( X1, output,  4 );
@@ -675,9 +675,9 @@ void aes_encrypt( aes_context *ctx, uint8 input[16], uint8 output[16] )
 
 /* AES 128-bit block decryption routine */
 
-void aes_decrypt( aes_context *ctx, uint8 input[16], uint8 output[16] )
+void aes_decrypt( aes_context *ctx, uint8_t input[16], uint8_t output[16] )
 {
-    uint32 *RK, X0, X1, X2, X3, Y0, Y1, Y2, Y3;
+    uint32_t *RK, X0, X1, X2, X3, Y0, Y1, Y2, Y3;
 
     RK = ctx->drk;
 
@@ -690,25 +690,25 @@ void aes_decrypt( aes_context *ctx, uint8 input[16], uint8 output[16] )
 {                                               \
     RK += 4;                                    \
                                                 \
-    X0 = RK[0] ^ RT0[ (uint8) ( Y0 >> 24 ) ] ^  \
-                 RT1[ (uint8) ( Y3 >> 16 ) ] ^  \
-                 RT2[ (uint8) ( Y2 >>  8 ) ] ^  \
-                 RT3[ (uint8) ( Y1       ) ];   \
+    X0 = RK[0] ^ RT0[ (uint8_t) ( Y0 >> 24 ) ] ^  \
+                 RT1[ (uint8_t) ( Y3 >> 16 ) ] ^  \
+                 RT2[ (uint8_t) ( Y2 >>  8 ) ] ^  \
+                 RT3[ (uint8_t) ( Y1       ) ];   \
                                                 \
-    X1 = RK[1] ^ RT0[ (uint8) ( Y1 >> 24 ) ] ^  \
-                 RT1[ (uint8) ( Y0 >> 16 ) ] ^  \
-                 RT2[ (uint8) ( Y3 >>  8 ) ] ^  \
-                 RT3[ (uint8) ( Y2       ) ];   \
+    X1 = RK[1] ^ RT0[ (uint8_t) ( Y1 >> 24 ) ] ^  \
+                 RT1[ (uint8_t) ( Y0 >> 16 ) ] ^  \
+                 RT2[ (uint8_t) ( Y3 >>  8 ) ] ^  \
+                 RT3[ (uint8_t) ( Y2       ) ];   \
                                                 \
-    X2 = RK[2] ^ RT0[ (uint8) ( Y2 >> 24 ) ] ^  \
-                 RT1[ (uint8) ( Y1 >> 16 ) ] ^  \
-                 RT2[ (uint8) ( Y0 >>  8 ) ] ^  \
-                 RT3[ (uint8) ( Y3       ) ];   \
+    X2 = RK[2] ^ RT0[ (uint8_t) ( Y2 >> 24 ) ] ^  \
+                 RT1[ (uint8_t) ( Y1 >> 16 ) ] ^  \
+                 RT2[ (uint8_t) ( Y0 >>  8 ) ] ^  \
+                 RT3[ (uint8_t) ( Y3       ) ];   \
                                                 \
-    X3 = RK[3] ^ RT0[ (uint8) ( Y3 >> 24 ) ] ^  \
-                 RT1[ (uint8) ( Y2 >> 16 ) ] ^  \
-                 RT2[ (uint8) ( Y1 >>  8 ) ] ^  \
-                 RT3[ (uint8) ( Y0       ) ];   \
+    X3 = RK[3] ^ RT0[ (uint8_t) ( Y3 >> 24 ) ] ^  \
+                 RT1[ (uint8_t) ( Y2 >> 16 ) ] ^  \
+                 RT2[ (uint8_t) ( Y1 >>  8 ) ] ^  \
+                 RT3[ (uint8_t) ( Y0       ) ];   \
 }
 
     AES_RROUND( Y0, Y1, Y2, Y3, X0, X1, X2, X3 );       /* round 1 */
@@ -737,25 +737,25 @@ void aes_decrypt( aes_context *ctx, uint8 input[16], uint8 output[16] )
 
     RK += 4;
 
-    X0 = RK[0] ^ ( RSb[ (uint8) ( Y0 >> 24 ) ] << 24 ) ^
-                 ( RSb[ (uint8) ( Y3 >> 16 ) ] << 16 ) ^
-                 ( RSb[ (uint8) ( Y2 >>  8 ) ] <<  8 ) ^
-                 ( RSb[ (uint8) ( Y1       ) ]       );
+    X0 = RK[0] ^ ( RSb[ (uint8_t) ( Y0 >> 24 ) ] << 24 ) ^
+                 ( RSb[ (uint8_t) ( Y3 >> 16 ) ] << 16 ) ^
+                 ( RSb[ (uint8_t) ( Y2 >>  8 ) ] <<  8 ) ^
+                 ( RSb[ (uint8_t) ( Y1       ) ]       );
 
-    X1 = RK[1] ^ ( RSb[ (uint8) ( Y1 >> 24 ) ] << 24 ) ^
-                 ( RSb[ (uint8) ( Y0 >> 16 ) ] << 16 ) ^
-                 ( RSb[ (uint8) ( Y3 >>  8 ) ] <<  8 ) ^
-                 ( RSb[ (uint8) ( Y2       ) ]       );
+    X1 = RK[1] ^ ( RSb[ (uint8_t) ( Y1 >> 24 ) ] << 24 ) ^
+                 ( RSb[ (uint8_t) ( Y0 >> 16 ) ] << 16 ) ^
+                 ( RSb[ (uint8_t) ( Y3 >>  8 ) ] <<  8 ) ^
+                 ( RSb[ (uint8_t) ( Y2       ) ]       );
 
-    X2 = RK[2] ^ ( RSb[ (uint8) ( Y2 >> 24 ) ] << 24 ) ^
-                 ( RSb[ (uint8) ( Y1 >> 16 ) ] << 16 ) ^
-                 ( RSb[ (uint8) ( Y0 >>  8 ) ] <<  8 ) ^
-                 ( RSb[ (uint8) ( Y3       ) ]       );
+    X2 = RK[2] ^ ( RSb[ (uint8_t) ( Y2 >> 24 ) ] << 24 ) ^
+                 ( RSb[ (uint8_t) ( Y1 >> 16 ) ] << 16 ) ^
+                 ( RSb[ (uint8_t) ( Y0 >>  8 ) ] <<  8 ) ^
+                 ( RSb[ (uint8_t) ( Y3       ) ]       );
 
-    X3 = RK[3] ^ ( RSb[ (uint8) ( Y3 >> 24 ) ] << 24 ) ^
-                 ( RSb[ (uint8) ( Y2 >> 16 ) ] << 16 ) ^
-                 ( RSb[ (uint8) ( Y1 >>  8 ) ] <<  8 ) ^
-                 ( RSb[ (uint8) ( Y0       ) ]       );
+    X3 = RK[3] ^ ( RSb[ (uint8_t) ( Y3 >> 24 ) ] << 24 ) ^
+                 ( RSb[ (uint8_t) ( Y2 >> 16 ) ] << 16 ) ^
+                 ( RSb[ (uint8_t) ( Y1 >>  8 ) ] <<  8 ) ^
+                 ( RSb[ (uint8_t) ( Y0       ) ]       );
 
     PUT_UINT32( X0, output,  0 );
     PUT_UINT32( X1, output,  4 );
@@ -782,7 +782,7 @@ static unsigned char AES_enc_test[3][16] =
     { 0x1F, 0x67, 0x63, 0xDF, 0x80, 0x7A, 0x7E, 0x70,
       0x96, 0x0D, 0x4C, 0xD3, 0x11, 0x8E, 0x60, 0x1A }
 };
-    
+
 static unsigned char AES_dec_test[3][16] =
 {
     { 0xF5, 0xBF, 0x8B, 0x37, 0x13, 0x6F, 0x2E, 0x1F,
@@ -792,7 +792,7 @@ static unsigned char AES_dec_test[3][16] =
     { 0x4D, 0xE0, 0xC6, 0xDF, 0x7C, 0xB1, 0x69, 0x72,
       0x84, 0x60, 0x4D, 0x60, 0x27, 0x1B, 0xC5, 0x9A }
 };
-    
+
 int main( void )
 {
     int m, n, i, j;
@@ -861,4 +861,3 @@ int main( void )
 }
 
 #endif
-

--- a/src/aes.h
+++ b/src/aes.h
@@ -1,24 +1,18 @@
 #ifndef _AES_H
 #define _AES_H
 
-#ifndef uint8
-#define uint8  unsigned char
-#endif
-
-#ifndef uint32
-#define uint32 unsigned long int
-#endif
+#include <stdint.h>
 
 typedef struct
 {
-    uint32 erk[64];     /* encryption round keys */
-    uint32 drk[64];     /* decryption round keys */
+    uint32_t erk[64];     /* encryption round keys */
+    uint32_t drk[64];     /* decryption round keys */
     int nr;             /* number of rounds */
 }
 aes_context;
 
-int  aes_set_key( aes_context *ctx, uint8 *key, int nbits );
-void aes_encrypt( aes_context *ctx, uint8 input[16], uint8 output[16] );
-void aes_decrypt( aes_context *ctx, uint8 input[16], uint8 output[16] );
+int  aes_set_key( aes_context *ctx, uint8_t *key, int nbits );
+void aes_encrypt( aes_context *ctx, uint8_t input[16], uint8_t output[16] );
+void aes_decrypt( aes_context *ctx, uint8_t input[16], uint8_t output[16] );
 
 #endif /* aes.h */

--- a/src/aes_ctr.c
+++ b/src/aes_ctr.c
@@ -1,6 +1,6 @@
 /*
 *   Byte-oriented AES-256 implementation.
-*   All lookup tables replaced with 'on the fly' calculations. 
+*   All lookup tables replaced with 'on the fly' calculations.
 *
 *   Copyright (c) 2007-2009 Ilya O. Levin, http://www.literatecode.com
 *   Other contributors: Hal Finney

--- a/src/aes_ctr.h
+++ b/src/aes_ctr.h
@@ -1,6 +1,6 @@
-/*  
+/*
 *   Byte-oriented AES-256 implementation.
-*   All lookup tables replaced with 'on the fly' calculations. 
+*   All lookup tables replaced with 'on the fly' calculations.
 *
 *   Copyright (c) 2007-2009 Ilya O. Levin, http://www.literatecode.com
 *   Other contributors: Hal Finney
@@ -19,7 +19,7 @@
 *   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 #ifndef uint8_t
-#define uint8_t  unsigned char
+#include <stdint.h>
 #endif
 #ifndef size_t
 #include <stddef.h>


### PR DESCRIPTION
This piece of code:

```c
#define uint32 unsigned long int
```

Defined `uint32` as a 64bit unsigned integer on my system (macOS, clang), using the proper types from `stdint.h` resolves this.