### PR TITLE
Fix disconnect on HomePod every 30s

### DIFF
--- a/src/raop_client.c
+++ b/src/raop_client.c
@@ -1363,8 +1363,8 @@ void *_rtp_control_thread(void *args)
 		fd_set rfds;
 		uint64_t now = raopcl_get_ntp(NULL);
 
-		// Send keepalive packet every 30 seconds
-		if (now - raopcld->last_keepalive >= MS2NTP(30000)) {
+		// Send keepalive packet every 25 seconds
+		if (now - raopcld->last_keepalive >= MS2NTP(25000)) {
 			LOG_INFO("[%p]: sending keepalive packet", raopcld);
 			if (raopcl_keepalive(raopcld)) {
 				raopcld->last_keepalive = now;

--- a/src/rtsp_client.c
+++ b/src/rtsp_client.c
@@ -659,8 +659,9 @@ static bool exec_request(struct rtspcl_s *rtspcld, char *cmd, char *content_type
 
 	token = strtok(line, delimiters);
 	token = strtok(NULL, delimiters);
-	if (token == NULL || strcmp(token, "200")) {
-		LOG_ERROR("[%p]: <------ : request failed, error %s", rtspcld, line);
+	// allow 501 status of HomePod for keepalive packet (OPTIONS)
+	if (token == NULL || (strcmp(token, "200") && (strcmp(token, "501") || strcmp(cmd, "OPTIONS")))) {
+		LOG_ERROR("[%p]: <------ : request failed, error %s %s", rtspcld, line, (token ? token : ""));
 		if (get_response == 1) return false;
 	} else {
 		LOG_DEBUG("[%p]: <------ : %s: request ok", rtspcld, token);


### PR DESCRIPTION
I have similar issue with #39.
Almost all music files doesn't stop but a music file stops after 30 seconds from the start on HomePod mini.
I tried the patch #40, but it seems to be required to send the keepalive packet before 30s, so I changed 25s.
`raopcl_keepalive(raopcld)` does not return true and `last_keepalive` is not updated on my test because HomePod returns 501 (Not Implemented) status. So I changed it to return true for 501 status and receive response headers from HomePod.